### PR TITLE
Add last modified date in the header

### DIFF
--- a/themes/osi/inc/template-functions.php
+++ b/themes/osi/inc/template-functions.php
@@ -209,7 +209,7 @@ function osi_press_mentions_by_publication_date( $query ) {
 */
 
 function osi_the_page_dates() {
-	if ( ! is_home() && ! is_front_page() ) {
+	if ( is_page() && ! is_home() && ! is_front_page() ) {
 		$max_date = '2023-02-01'; // February 1, 2023
 		$created  = get_the_date( 'F j, Y' );
 		$modified = get_the_modified_date( 'F j, Y' );

--- a/themes/osi/template-parts/content-page.php
+++ b/themes/osi/template-parts/content-page.php
@@ -15,6 +15,4 @@
 			<?php the_content(); ?>
 		</div><!-- .entry-content -->
 
-		<?php osi_the_page_dates(); ?>
-
 	</article><!-- #post-<?php the_ID(); ?> -->

--- a/themes/osi/template-parts/header-featured-image.php
+++ b/themes/osi/template-parts/header-featured-image.php
@@ -9,7 +9,7 @@ if ( function_exists( 'Sugar_Calendar\AddOn\Ticketing\Settings\get_setting' ) ) 
 	}
 }
 
-if( ! isset( $page_title ) ) {
+if ( ! isset( $page_title ) ) {
 	$page_title = get_the_title();
 }
 
@@ -28,6 +28,7 @@ if( ! isset( $page_title ) ) {
 		<div class="wp-block-cover alignfull has-neutral-dark-background-color has-background-dim-100 has-background-dim">
 			<div class="wp-block-cover__inner-container">
 				<?php echo ( ! empty( $page_title ) ) ? '<h1 class="entry-title page--title">' . esc_html( $page_title ) . '</h1>' : ''; ?>
+				<?php osi_the_page_dates(); ?>
 			</div>
 		</div>
 	</header>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added the creation and last modified dates to the page header
* Keep the dates at the bottom of the page is the page isn't using a header

#### Testing instructions

* Open an old page (created before Feb 2023) from the Frontend
* Confirm that the Created and Last modified dates appear in the header, just below the title.
* Edit the page and change its template to "No page header"
* Open it from the Frontend and confirm that the page dates appear at the bottom of the page.

#### Screenshots
**Page with header**
![image](https://github.com/OpenSourceOrg/dotOrg/assets/1201868/b2b57df6-11e0-486f-a816-49b405092be7)


**Page without header**
![image](https://github.com/OpenSourceOrg/dotOrg/assets/1201868/b4f5f9fb-2a28-4f24-ac22-1670339aea75)


Mentions #9