### PR TITLE
Add last modified date in the header

### DIFF
--- a/themes/osi/inc/template-functions.php
+++ b/themes/osi/inc/template-functions.php
@@ -210,8 +210,13 @@ function osi_press_mentions_by_publication_date( $query ) {
 
 function osi_the_page_dates() {
 	if ( ! is_home() && ! is_front_page() ) {
+		$max_date = '2023-02-01'; // February 1, 2023
 		$created  = get_the_date( 'F j, Y' );
 		$modified = get_the_modified_date( 'F j, Y' );
-		echo sprintf( '<h4 class="page_dates">Page created on %1$s | Last modified on %2$s</h4>', esc_html( $created ), esc_html( $modified ) );
+
+		if ( strtotime( $created ) < strtotime( $max_date ) ) {
+			// Post was created before the 'max date'.
+			echo sprintf( '<h4 class="page_dates">Page created on %1$s | Last modified on %2$s</h4>', esc_html( $created ), esc_html( $modified ) );
+		}
 	}
 }

--- a/themes/osi/inc/template-functions.php
+++ b/themes/osi/inc/template-functions.php
@@ -169,7 +169,6 @@ if ( ! function_exists( 'get_license_search_query' ) ) {
 		$query = sanitize_text_field( $query );
 
 		return $query;
-
 	}
 }
 
@@ -177,7 +176,7 @@ if ( ! function_exists( 'get_license_search_query' ) ) {
 // Meta Block Field Filter Date
 add_filter( 'meta_field_block_get_block_content', 'osi_filter_meta_block_date_output', 10, 4 );
 function osi_filter_meta_block_date_output( $content, $attributes, $block, $post_id ) {
-	if ( is_numeric( $content ) && 8 == strlen( $content ) ) {
+	if ( is_numeric( $content ) && 8 === strlen( $content ) ) {
 		$content = DateTime::createFromFormat( 'Ymd', $content )->format( 'M Y' );
 	}
 	return $content;
@@ -187,17 +186,32 @@ function osi_filter_meta_block_date_output( $content, $attributes, $block, $post
 add_action( 'pre_get_posts', 'osi_press_mentions_by_publication_date' );
 function osi_press_mentions_by_publication_date( $query ) {
 	if ( ! is_admin() && $query->is_main_query() ) {
-		if( is_post_type_archive( 'press-mentions' ) ) {
+		if ( is_post_type_archive( 'press-mentions' ) ) {
 			$query->set( 'meta_key', 'date_of_publication' );
 			$query->set( 'orderby', 'meta_value_num' );
-			$query->set( 'order', 'DESC');
-			$query->set( 'meta_query', array(
+			$query->set( 'order', 'DESC' );
+			$query->set(
+				'meta_query',
 				array(
-					'key'     => 'date_of_publication',
-					'type'    => 'numeric',
-            	)
-       		 ) );
+					array(
+						'key'  => 'date_of_publication',
+						'type' => 'numeric',
+					),
+				)
+			);
 		}
 	}
 	return $query;
+}
+
+/**
+* Renders the "Created" and "Last modified" string for a page.
+*/
+
+function osi_the_page_dates() {
+	if ( ! is_home() && ! is_front_page() ) {
+		$created  = get_the_date( 'F j, Y' );
+		$modified = get_the_modified_date( 'F j, Y' );
+		echo sprintf( '<h4 class="page_dates">Page created on %1$s | Last modified on %2$s</h4>', esc_html( $created ), esc_html( $modified ) );
+	}
 }

--- a/themes/osi/inc/template-functions.php
+++ b/themes/osi/inc/template-functions.php
@@ -209,7 +209,7 @@ function osi_press_mentions_by_publication_date( $query ) {
 */
 
 function osi_the_page_dates() {
-	if ( ! is_home() && ! is_front_page() ) {
+	if ( is_page() && ! is_home() && ! is_front_page() ) {
 		$max_date = '2023-02-01'; // February 1, 2023
 		$created  = get_the_date( 'F j, Y' );
 		$modified = get_the_modified_date( 'F j, Y' );

--- a/themes/osi/template-parts/content-page-no-header.php
+++ b/themes/osi/template-parts/content-page-no-header.php
@@ -14,4 +14,6 @@
 			<?php the_content(); ?>
 		</div><!-- .entry-content -->
 
+		<?php osi_the_page_dates(); ?>
+
 	</article><!-- #post-<?php the_ID(); ?> -->

--- a/themes/osi/template-parts/content-page.php
+++ b/themes/osi/template-parts/content-page.php
@@ -15,4 +15,6 @@
 			<?php the_content(); ?>
 		</div><!-- .entry-content -->
 
+		<?php osi_the_page_dates(); ?>
+
 	</article><!-- #post-<?php the_ID(); ?> -->

--- a/themes/osi/template-parts/content-page.php
+++ b/themes/osi/template-parts/content-page.php
@@ -15,6 +15,4 @@
 			<?php the_content(); ?>
 		</div><!-- .entry-content -->
 
-		<?php osi_the_page_dates(); ?>
-
 	</article><!-- #post-<?php the_ID(); ?> -->

--- a/themes/osi/template-parts/header-featured-image.php
+++ b/themes/osi/template-parts/header-featured-image.php
@@ -9,7 +9,7 @@ if ( function_exists( 'Sugar_Calendar\AddOn\Ticketing\Settings\get_setting' ) ) 
 	}
 }
 
-if( ! isset( $page_title ) ) {
+if ( ! isset( $page_title ) ) {
 	$page_title = get_the_title();
 }
 
@@ -28,6 +28,7 @@ if( ! isset( $page_title ) ) {
 		<div class="wp-block-cover alignfull has-neutral-dark-background-color has-background-dim-100 has-background-dim">
 			<div class="wp-block-cover__inner-container">
 				<?php echo ( ! empty( $page_title ) ) ? '<h1 class="entry-title page--title">' . esc_html( $page_title ) . '</h1>' : ''; ?>
+				<?php osi_the_page_dates(); ?>
 			</div>
 		</div>
 	</header>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added the creation and last modified dates to the page header
* Keep the dates at the bottom of the page is the page isn't using a header

#### Testing instructions

* Open an old page (created before Feb 2023) from the Frontend
* Confirm that the Created and Last modified dates appear in the header, just below the title.
* Edit the page and change its template to "No page header"
* Open it from the Frontend and confirm that the page dates appear at the bottom of the page.

#### Screenshots
**Page with header**
![image](https://github.com/OpenSourceOrg/dotOrg/assets/1201868/b2b57df6-11e0-486f-a816-49b405092be7)


**Page without header**
![image](https://github.com/OpenSourceOrg/dotOrg/assets/1201868/b4f5f9fb-2a28-4f24-ac22-1670339aea75)


Mentions #9