### PR TITLE
Change CPT name to "Press Mentions"

### DIFF
--- a/plugins/osi-features/inc/classes/post-types/class-post-type-press-mentions.php
+++ b/plugins/osi-features/inc/classes/post-types/class-post-type-press-mentions.php
@@ -24,7 +24,7 @@ class Post_Type_Press_Mentions extends Base {
 	 *
 	 * @var string
 	 */
-	const LABEL = 'In The News';
+	const LABEL = 'Press mentions';
 
 	/**
 	 * To get list of labels for post type.
@@ -34,17 +34,17 @@ class Post_Type_Press_Mentions extends Base {
 	public function get_labels() {
 
 		return [
-			'name'               => __( 'In The News', 'osi-features' ),
-			'singular_name'      => __( 'Articles', 'osi-features' ),
-			'all_items'          => __( 'Articles', 'osi-features' ),
+			'name'               => __( 'Press mentions', 'osi-features' ),
+			'singular_name'      => __( 'Press mentions', 'osi-features' ),
+			'all_items'          => __( 'Press mentions', 'osi-features' ),
 			'add_new'            => __( 'Add New', 'osi-features' ),
-			'add_new_item'       => __( 'Add New Article', 'osi-features' ),
-			'edit_item'          => __( 'Edit Article', 'osi-features' ),
-			'new_item'           => __( 'New Article', 'osi-features' ),
-			'view_item'          => __( 'View Article', 'osi-features' ),
-			'search_items'       => __( 'Search Articles', 'osi-features' ),
-			'not_found'          => __( 'No Articles found', 'osi-features' ),
-			'not_found_in_trash' => __( 'No Articles found in Trash', 'osi-features' ),
+			'add_new_item'       => __( 'Add New Press mention', 'osi-features' ),
+			'edit_item'          => __( 'Edit Press mention', 'osi-features' ),
+			'new_item'           => __( 'New Press mention', 'osi-features' ),
+			'view_item'          => __( 'View Press mention', 'osi-features' ),
+			'search_items'       => __( 'Search Press mentions', 'osi-features' ),
+			'not_found'          => __( 'No Press mentions found', 'osi-features' ),
+			'not_found_in_trash' => __( 'No Press mentions found in Trash', 'osi-features' ),
 		];
 
 	}
@@ -62,7 +62,7 @@ class Post_Type_Press_Mentions extends Base {
 			'has_archive'   => true,
 			'menu_position' => 6,
 			'supports'      => [ 'title', 'author', 'excerpt' ],
-			'rewrite'       => [ 'slug' => 'in-the-news' ]
+			'rewrite'       => [ 'slug' => 'press-mentions' ]
 		];
 
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Changed the "In the news" CPT name to "Press mentions"

#### Testing instructions

* Log in to the backend and confirm that the former "In the news" CPT appears now with the "Press mentions" label
* Flush the permalinks
* Open any "Press mention" post and confirm that "press-mentions" appears in the URL and the post is available.

Mentions #25