### PR TITLE
Added "No Header with title" template

### DIFF
--- a/themes/osi/templates/template-no-header-title.php
+++ b/themes/osi/templates/template-no-header-title.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Template Name: No Header with Title
+ *
+ * @link https://codex.wordpress.org/Template_Hierarchy
+ *
+ * @package osi
+ */
+
+get_header(); ?>
+
+<section class="content <?php echo ( osi_display_sidebar() ? 'has_sidebar' : 'has_no_sidebar' ); ?>" id="content">
+
+	<main class="content--body <?php echo esc_attr( osi_main_class() ); ?>" role="main">
+
+		<section class="content--page" id="content-page">
+			<?php get_template_part( 'template-parts/breadcrumbs' ); ?>
+
+			<?php
+			while ( have_posts() ) :
+				the_post();
+				the_title( '<h1>', '</h1>' );
+				get_template_part( 'template-parts/content', 'page-no-header' );
+
+			endwhile; // End of the loop.
+			?>
+
+		</section>
+
+	</main><!-- #primary -->
+
+</section>
+
+<?php
+get_footer();


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Created the "No Header with Title" template

#### Testing instructions

* Edit a page and assign it the "No Header with Title" template to it
* Assign a featured image to the page
* Open the page from the Frontend and confirm that the featured image isn't being displayed in the header 
* Confirm that the title (h1) is also rendered before the page content

Mentions #19