### PR TITLE
Added a footer sidebar and removed max-width limitation 

### DIFF
--- a/themes/osi/footer.php
+++ b/themes/osi/footer.php
@@ -32,8 +32,13 @@ $footerclass = is_active_sidebar( 'sidebar-footer' ) ? 'widgetized-footer footer
 				<div class="footer--inner">
 					<div class="widgetized-footer footer--widgets wp-block-columns alignwide">
 					<?php dynamic_sidebar( 'sidebar-footer-secondary' ); ?>
-						<div class="wp-block-column" style="max-width:480px">
+						<div class="wp-block-column">
 							<p class="footer--extra-text">
+							<?php
+							if ( is_active_sidebar( 'footer-above-credits' ) ) {
+								dynamic_sidebar( 'footer-above-credits' );
+							}
+							?>
 								<?php do_action( 'osi_credits' ); ?>
 							</p><!-- .powered-by-wordpress -->
 						</div>

--- a/themes/osi/functions.php
+++ b/themes/osi/functions.php
@@ -313,3 +313,21 @@ require get_template_directory() . '/inc/class-svg.php';
  * Load the Sugar Calendar compatibility file.
  */
 require get_template_directory() . '/inc/sugar-calendar.php';
+
+/**
+ * Register the "Footer - Above credits" sidebar.
+ */
+function register_footer_above_sidebar() {
+    register_sidebar(
+		array(
+			'name'          => esc_html__( 'Footer - Above Credits', 'osi' ),
+			'id'            => 'footer-above-credits',
+			'description'   => esc_html__( 'Add widgets here to appear above the credits in the footer.', 'osi' ),
+			'before_widget' => '<div id="%1$s" class="widget %2$s">',
+			'after_widget'  => '</div>',
+			'before_title'  => '<h2 class="widget-title">',
+			'after_title'   => '</h2>',
+    	)
+	);
+}
+add_action('widgets_init', 'register_footer_above_sidebar');


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added the "Footer - Above credits" sidebar
* Removed the max-width restriction from the footer

#### Testing instructions

* Go to Appearance > Widgets and confirm that there's a sidebar named "Footer - Above credits"
* Add content there
* Open any page from the Frontend and confirm that this content gets rendered in the footer, above the colophon credits
* Confirm that the content of the footer is taking the 100% of its width.

Mentions #21