### PR TITLE
Fix : Free Tickets

### DIFF
--- a/themes/osi/inc/sugar-calendar.php
+++ b/themes/osi/inc/sugar-calendar.php
@@ -294,7 +294,7 @@ function osi_purchase_button_html( $button_html, $event ) {
 	$ticket_price = get_event_meta( $event->id, 'ticket_price', true );
 
 	// If the price is $0.0, Button text should be replace by 'Register'.
-	if ( 0.0 === $ticket_price ) {
+	if ( 0.0 === (float) $ticket_price ) {
 		$button_html = str_replace( 'Add to Cart', __( 'Register', 'osi' ), $button_html );
 	}
 


### PR DESCRIPTION
### Issue
- https://github.com/OpenSourceOrg/dotOrg/pull/36

### Fixes proposed
- When setting the ticket price, if the price is `0`, it should be set to `0.0` else the weird characters appear
- This is the default functionality of the `Sugar Calendar` plugin `Util` functions
- Replace $0.0 Per Ticket with Free Event
- Replace `Get a Ticket` button text with `Register`

### Preview
<img width="1077" alt="Screenshot 2024-01-19 at 4 21 22 PM" src="https://github.com/OpenSourceOrg/dotOrg/assets/71686151/2446b97b-bf92-4790-b57d-26825d26baf1">