### PR TITLE
Add: WebSub backwards compatibility for the blog subdomain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ mu-plugins/*
 !mu-plugins/mu-autoloader.php
 !mu-plugins/osi-event-list
 !mu-plugins/osi-sponsors-list
+!websub-compat.php
 
 themes/*
 !themes/osi

--- a/mu-plugins/websub-compat.php
+++ b/mu-plugins/websub-compat.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Plugin Name: WebSub Backwards Compatibility
+ * Plugin Description: Still send pings for the old `blog.opensource.org` Feed-URLs.
  * Version: 1.0.0
  * Author: WordPress.com Special Projects
  * Author URI: https://wpspecialprojects.wordpress.com/

--- a/mu-plugins/websub-compat.php
+++ b/mu-plugins/websub-compat.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array $links Array of filtered Feed URLs.
  */
 function websub_compat( array $links ) {
-	if ( ! $links || ! is_array( $links ) ) {
+	if ( ! $links ) {
 		return $links;
 	}
 

--- a/mu-plugins/websub-compat.php
+++ b/mu-plugins/websub-compat.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Plugin Name: WebSub Backwards Compatibility
+ * Version: 1.0.0
+ * Author: WordPress.com Special Projects
+ * Author URI: https://wpspecialprojects.wordpress.com/
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	return;
+}
+
+/**
+ * Filter `pubsubhubbub_feed_urls` and `pubsubhubbub_comment_feed_urls`.
+ *
+ * Still send pings for the old `blog.opensource.org` Feed-URLs.
+ *
+ * @param array $links Array of Feed URLs.
+ *
+ * @return array $links Array of filtered Feed URLs.
+ */
+function websub_compat( $links ) {
+	if ( ! $links || ! is_array( $links ) ) {
+		return $links;
+	}
+
+	$host         = wp_parse_url( get_home_url(), PHP_URL_HOST );
+	$compat_links = array();
+
+	foreach ( $links as $link ) {
+		$compat_links[] = str_replace( $host, 'blog.' . $host, $link );
+	}
+
+	return array_unique( array_merge( $links, $compat_links ) );
+}
+add_filter( 'pubsubhubbub_feed_urls', 'websub_compat' );
+add_filter( 'pubsubhubbub_comment_feed_urls', 'websub_compat' );

--- a/mu-plugins/websub-compat.php
+++ b/mu-plugins/websub-compat.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @return array $links Array of filtered Feed URLs.
  */
-function websub_compat( $links ) {
+function websub_compat( array $links ) {
 	if ( ! $links || ! is_array( $links ) ) {
 		return $links;
 	}


### PR DESCRIPTION
Still send pings for the old `blog.opensource.org` Feed-URLs.

#### Changes proposed in this Pull Request

* The PR adds the `blog.opensource.org` Feed URLs to the list of updated Feed URLs, to keep backwards compatibility.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #