### PR TITLE
Add Actor migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ plugins/*
 
 mu-plugins/*
 !mu-plugins/mu-autoloader.php
+!mu-plugins/activitypub-migration.php
 !mu-plugins/osi-event-list
 !mu-plugins/osi-sponsors-list
 

--- a/mu-plugins/activitypub-migration.php
+++ b/mu-plugins/activitypub-migration.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Plugin Name: ActivityPub Migration
+ * Plugin Description: Adds the `blog.opensource.org` to the Actors `alsoKnownAs` list.
+ * Version: 1.0.0
+ * Author: WordPress.com Special Projects
+ * Author URI: https://wpspecialprojects.wordpress.com/
+ */
+
+ if ( ! defined( 'ABSPATH' ) ) {
+	return;
+}
+
+/**
+ * Adds the `blog.opensource.org` to the Actors `alsoKnownAs` list.
+ *
+ * @param array $actor Actor as Array.
+ *
+ * @return array $actor Filtered Actor Array.
+ */
+function activitypub_actor_migration( array $actor ) {
+	if ( ! $actor ) {
+		return $actor;
+	}
+
+	$host = wp_parse_url( get_home_url(), PHP_URL_HOST );
+	$id   = str_replace( $host, 'blog.' . $host, $actor['id'] );
+
+	$actor['alsoKnownAs'] = array( $id );
+	return $actor;
+}
+add_filter( 'activitypub_activity_user_object_array', 'activitypub_actor_migration' );

--- a/mu-plugins/activitypub-migration.php
+++ b/mu-plugins/activitypub-migration.php
@@ -7,7 +7,7 @@
  * Author URI: https://wpspecialprojects.wordpress.com/
  */
 
- if ( ! defined( 'ABSPATH' ) ) {
+if ( ! defined( 'ABSPATH' ) ) {
 	return;
 }
 


### PR DESCRIPTION
This adds the fields that are required for the ActivityPub target domain.

#### Changes proposed in this Pull Request

* https://docs.joinmastodon.org/user/moving/
* https://blog.joinmastodon.org/2019/06/how-to-migrate-from-one-server-to-another/


