### PR TITLE
Add rewrite slug to custom post types

### DIFF
--- a/plugins/osi-features/inc/classes/post-types/class-base.php
+++ b/plugins/osi-features/inc/classes/post-types/class-base.php
@@ -79,6 +79,10 @@ abstract class Base {
 			'has_archive'   => true,
 			'menu_position' => 6,
 			'supports'      => [ 'title', 'editor', 'author', 'thumbnail', 'excerpt', 'comments' ],
+			'rewrite'            => array(
+				'slug'       => $this->get_slug(),
+				'with_front' => false,
+			)
 		];
 
 	}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

- Add rewrite slug to custom post types so CPTs don't pick up the `/blog/` permalink added to blog posts.

#### Testing instructions

1. Save permalinks
2. CPTs should not have `/blog/` added to URLs
