### PR TITLE
Fix rewrite URL for press mentions

### DIFF
--- a/plugins/osi-features/inc/classes/post-types/class-post-type-press-mentions.php
+++ b/plugins/osi-features/inc/classes/post-types/class-post-type-press-mentions.php
@@ -62,7 +62,7 @@ class Post_Type_Press_Mentions extends Base {
 			'has_archive'   => true,
 			'menu_position' => 6,
 			'supports'      => [ 'title', 'author', 'excerpt' ],
-			'rewrite'       => [ 'slug' => 'press-mentions' ]
+			'rewrite'       => [ 'slug' => 'press-mentions', 'with_front' => false ]
 		];
 
 	}


### PR DESCRIPTION
#### Changes proposed in Pull Request

- Add rewrite slug to press mentions so CPTs don't pick up the `/blog/` permalink added to blog posts.

#### Testing instructions

1. Save permalinks
2. Press mentions should not have `/blog/` added to URLs