### PR TITLE
Protecting against Sugar Calendar deactivation

### DIFF
--- a/themes/osi/archive-sc_event.php
+++ b/themes/osi/archive-sc_event.php
@@ -6,6 +6,14 @@
  *
  * @package osi
  */
+
+if ( ! class_exists( 'Sugar_Calendar\\Requirements_Check' ) ) {
+	add_action('init', function() {
+		wp_safe_redirect( home_url() );
+		exit; 
+	});
+}
+
 $display_type         = isset( $_GET['event-display'] ) ? sanitize_text_field( wp_unslash( $_GET['event-display'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 $event_post_type_slug = sugar_calendar_get_event_post_type_id();
 

--- a/themes/osi/functions.php
+++ b/themes/osi/functions.php
@@ -329,8 +329,9 @@ require get_template_directory() . '/inc/class-svg.php';
 /**
  * Load the Sugar Calendar compatibility file.
  */
-require get_template_directory() . '/inc/sugar-calendar.php';
-
+if ( class_exists( 'Sugar_Calendar\\Requirements_Check' ) ) {
+	require get_template_directory() . '/inc/sugar-calendar.php';
+}
 /**
  * Register the "Footer - Above credits" sidebar.
  *

--- a/themes/osi/inc/sugar-calendar.php
+++ b/themes/osi/inc/sugar-calendar.php
@@ -8,6 +8,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if ( ! class_exists( 'Sugar_Calendar\\Requirements_Check' ) ) {
+	exit; 
+}
+
 use Sugar_Calendar\AddOn\Ticketing\Common\Functions as Functions;
 use Sugar_Calendar\AddOn\Ticketing\Frontend\Single as Single;
 

--- a/themes/osi/template-parts/content-press-mentions.php
+++ b/themes/osi/template-parts/content-press-mentions.php
@@ -13,7 +13,12 @@
 	<?php get_template_part( 'template-parts/header-featured-image' ); ?>
 
 	<div class="entry-content post--content">
-		<?php if ( get_post_type() !== sugar_calendar_get_event_post_type_id() ) { ?>
+		<?php 
+		$sugar_cal_post_type_id = 'placeholder';
+		if ( class_exists( 'Sugar_Calendar\\Requirements_Check' ) ) {
+			$sugar_cal_post_type_id = sugar_calendar_get_event_post_type_id();
+		}
+		if ( $sugar_cal_post_type_id !== get_post_type() ) { ?>
 
 			<div class="entry-meta post--byline">
 				<?php osi_posted_on(); ?>

--- a/themes/osi/template-parts/content.php
+++ b/themes/osi/template-parts/content.php
@@ -13,7 +13,12 @@
 	<?php get_template_part( 'template-parts/header-featured-image' ); ?>
 
 	<div class="entry-content post--content">
-		<?php if ( get_post_type() !== sugar_calendar_get_event_post_type_id() ) { ?>
+		<?php 
+		$sugar_cal_post_type_id = 'placeholder';
+		if ( class_exists( 'Sugar_Calendar\\Requirements_Check' ) ) {
+			$sugar_cal_post_type_id = sugar_calendar_get_event_post_type_id();
+		}
+		if ( $sugar_cal_post_type_id !== get_post_type() ) { ?>
 
 			<div class="entry-meta post--byline">
 				<?php osi_posted_on(); ?>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Adding conditionals to code to protect against Sugar Calendar plugin deactivation

#### Testing instructions

* Shouldn't get fatals when Sugar Calendar is deactivated, but everything should still work if it is. 

( dev request 3895 )