### PR TITLE
Display "Free" instead of 0.00$ (dev)

### DIFF
--- a/mu-plugins/osi-events-manager-tweaks/osi-events-manager-tweaks.php
+++ b/mu-plugins/osi-events-manager-tweaks/osi-events-manager-tweaks.php
@@ -7,7 +7,17 @@
  * Author URI: https://wpspecialprojects.wordpress.com/
  */
 
-add_filter('em_event_output_placeholder', 'osi_em_event_output_placeholder', 10, 5);
+ /**
+ * Remove the event time zone if the event is all day.
+ *
+ * @param string $replace         The string to replace.
+ * @param EM_Event $EM_Event      The event object.
+ * @param string $full_result     The full result.
+ * @param string $target          The target.
+ * @param array $placeholder_atts The placeholder attributes.
+ *
+ * @return string
+*/
 function osi_em_event_output_placeholder( $replace, $EM_Event, $full_result, $target, $placeholder_atts ) {
 	if ( '#_EVENTTIMEZONE' === $full_result ) {
 		$event_times = $EM_Event->output('#_EVENTTIMES');
@@ -17,3 +27,22 @@ function osi_em_event_output_placeholder( $replace, $EM_Event, $full_result, $ta
 	}
 	return $replace;
 }
+add_filter('em_event_output_placeholder', 'osi_em_event_output_placeholder', 10, 5);
+
+/**
+ * Display "Free" for events with a price of 0.00.
+ *
+ * @param string $formatted_price The formatted price.
+ * @param string $price           The price.
+ * @param string $currency        The currency.
+ * @param string $format          The format.
+ * @return void
+ */
+function osi_format_event_manager_price( $formatted_price, $price, $currency, $format ) {
+	if( 0.00 === (float)$price ) {
+		$formatted_price = 'Free';
+	}
+
+	return $formatted_price;
+}
+add_filter('em_get_currency_formatted', 'osi_format_event_manager_price', 10, 4 );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Display "Free" instead of 0.00$

#### Testing instructions
* Open an event page (like [this](https://open-source-initiative-development.mystagingwebsite.com/events/open-source-ai-definition-town-hall-may-31)) and confirm that if the event is free, "Free" is displayed instead of "$0.00"

Mentions https://github.com/a8cteam51/opensource-net/issues/49