### PR TITLE
Disable header for posts/events without featured image (dev)

### DIFF
--- a/themes/osi/template-parts/header-featured-image.php
+++ b/themes/osi/template-parts/header-featured-image.php
@@ -1,5 +1,4 @@
 <?php
-
 if ( function_exists( 'Sugar_Calendar\AddOn\Ticketing\Settings\get_setting' ) ) {
 
 	$recepit_page_id = Sugar_Calendar\AddOn\Ticketing\Settings\get_setting( 'receipt_page' );
@@ -23,7 +22,7 @@ if ( ! isset( $page_title ) ) {
 			</div>
 		</div>
 	</header>
-<?php } else if ( ! has_post_thumbnail() && ! in_array( get_post_type( $post ), array( 'post', 'event' ), true ) ) { ?>
+<?php } elseif ( ! has_post_thumbnail() && ! in_array( get_post_type( $post ), array( 'post', 'event' ), true ) ) { ?>
 	<header class="entry-header cover--header no-thumbnail">
 		<div class="wp-block-cover alignfull">
 			<div class="wp-block-cover__inner-container">

--- a/themes/osi/template-parts/header-featured-image.php
+++ b/themes/osi/template-parts/header-featured-image.php
@@ -15,7 +15,7 @@ if ( ! isset( $page_title ) ) {
 
 ?>
 
-<?php if ( has_post_thumbnail() && 'post' !== get_post_type( $post ) ) : ?>
+<?php if ( has_post_thumbnail() && 'post' !== get_post_type( $post ) ) { ?>
 	<header class="entry-header cover--header">
 		<div class="wp-block-cover alignfull">
 			<img class="wp-block-cover__image-background" alt="" src="<?php the_post_thumbnail_url(); ?>" data-object-fit="cover"/>
@@ -23,7 +23,7 @@ if ( ! isset( $page_title ) ) {
 			</div>
 		</div>
 	</header>
-<?php else : ?>
+<?php } else if ( ! has_post_thumbnail() && ! in_array( get_post_type( $post ), array( 'post', 'event' ), true ) ) { ?>
 	<header class="entry-header cover--header no-thumbnail">
 		<div class="wp-block-cover alignfull">
 			<div class="wp-block-cover__inner-container">
@@ -32,4 +32,4 @@ if ( ! isset( $page_title ) ) {
 			</div>
 		</div>
 	</header>
-<?php endif; ?>
+<?php } ?>


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disable header for posts/events without featured image

#### Testing instructions

* Open an event page from the Frontend (like [this one](https://open-source-initiative-development.mystagingwebsite.com/events/open-source-ai-definition-town-hall-2024-06-14))
* Confirm that if the event has a featured image, it gets rendered in the header
* Confirm that if the event doesn't have any featured image, no blank space is rendered in the header

Mentions [#](https://github.com/a8cteam51/opensource-net/issues/50)