### PR TITLE
Add breadcrumbs to the single Event page (dev)

### DIFF
--- a/themes/osi/index.php
+++ b/themes/osi/index.php
@@ -22,8 +22,12 @@ get_header(); ?>
 	if ( have_posts() ) :
 		?>
 		<section class="content--page" id="content-page">
-			<?php get_template_part( 'template-parts/breadcrumbs' ); ?>
-				<?php
+			<?php
+				if ( 'event' === get_post_type() ) {
+					get_template_part( 'template-parts/breadcrumbs-sc_event' );
+				} else {
+					get_template_part( 'template-parts/breadcrumbs' );
+				}
 				$count = 0;
 				/* Start the Loop */
 				while ( have_posts() ) :


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add breadcrumbs to the single Event page

#### Testing instructions

* Open a single event page from the Frontend
* Confirm that it has breadcrumbs, linking to the Home, the Events page and mentioning the current event.

Mentions https://github.com/a8cteam51/opensource-net/issues/50