### PR TITLE
Add breadcrumbs to the single Event page (dev)

### DIFF
--- a/themes/osi/index.php
+++ b/themes/osi/index.php
@@ -22,8 +22,12 @@ get_header(); ?>
 	if ( have_posts() ) :
 		?>
 		<section class="content--page" id="content-page">
-			<?php get_template_part( 'template-parts/breadcrumbs' ); ?>
-				<?php
+			<?php
+				if ( 'event' === get_post_type() ) {
+					get_template_part( 'template-parts/breadcrumbs-sc_event' );
+				} else {
+					get_template_part( 'template-parts/breadcrumbs' );
+				}
 				$count = 0;
 				/* Start the Loop */
 				while ( have_posts() ) :

--- a/themes/osi/page.php
+++ b/themes/osi/page.php
@@ -19,9 +19,12 @@ get_header(); ?>
 	<main class="content--body <?php echo esc_attr( osi_main_class() ); ?>" role="main">
 
 		<section class="content--page" id="content-page">
-			<?php get_template_part( 'template-parts/breadcrumbs' ); ?>
-
 			<?php
+			if ( 'event' === get_post_type() ) {
+				get_template_part( 'template-parts/breadcrumbs-sc_event' );
+			} else {
+				get_template_part( 'template-parts/breadcrumbs' );
+			}
 			while ( have_posts() ) :
 				the_post();
 

--- a/themes/osi/single.php
+++ b/themes/osi/single.php
@@ -13,9 +13,13 @@ get_header(); ?>
 
 	<main class="content--body <?php echo esc_attr( osi_main_class() ); ?>" role="main">
 		<section class="content--page" id="content-page">
-		<?php get_template_part( 'template-parts/breadcrumbs' ); ?>
-
 			<?php
+			if ( 'event' === get_post_type() ) {
+				get_template_part( 'template-parts/breadcrumbs-sc_event' );
+			} else {
+				get_template_part( 'template-parts/breadcrumbs' );
+			}
+			
 			while ( have_posts() ) :
 				the_post();
 

--- a/themes/osi/template-parts/breadcrumbs-sc_event.php
+++ b/themes/osi/template-parts/breadcrumbs-sc_event.php
@@ -3,15 +3,22 @@
 		<nav class="entry-breadcrumbs" itemscope="" itemtype="https://schema.org/BreadcrumbList">
 			<span itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
 				<meta itemprop="position" content="1">
-				<meta itemprop="position" content="0">
 				<a href="<?php echo esc_url( home_url( '/' ) ); ?>" class="home-link" itemprop="item" rel="home">
 					<span itemprop="name"><?php echo esc_html__( 'Home', 'osi' ); ?></span>
 				</a>
 			</span>
-			<span class="current-page" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
-				<meta itemprop="position" content="1">
-				<span itemprop="name"><?php echo esc_html__( 'Events', 'osi' ); ?></span>
+			<span itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
+				<meta itemprop="position" content="2">
+				<a href="<?php echo esc_url( home_url( '/events/' ) ); ?>" class="events-link" itemprop="item">
+					<span itemprop="name"><?php echo esc_html__( 'Events', 'osi' ); ?></span>
+				</a>
 			</span>
+			<?php if ( is_single() && get_post_type() == 'event' ) : ?>
+			<span class="current-page" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
+				<meta itemprop="position" content="3">
+				<span itemprop="name"><?php echo esc_html( get_the_title() ); ?></span>
+			</span>
+			<?php endif; ?>
 		</nav>
 	</div><!-- .wrapper -->
 </div><!-- .breadcrumb-area -->


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add breadcrumbs to the single Event page

#### Testing instructions

* Open a single event page from the Frontend
* Confirm that it has breadcrumbs, linking to the Home, the Events page and mentioning the current event.

Mentions https://github.com/a8cteam51/opensource-net/issues/50