### PR TITLE
Event page updates

### DIFF
--- a/themes/osi/index.php
+++ b/themes/osi/index.php
@@ -22,8 +22,12 @@ get_header(); ?>
 	if ( have_posts() ) :
 		?>
 		<section class="content--page" id="content-page">
-			<?php get_template_part( 'template-parts/breadcrumbs' ); ?>
-				<?php
+			<?php
+				if ( 'event' === get_post_type() ) {
+					get_template_part( 'template-parts/breadcrumbs-sc_event' );
+				} else {
+					get_template_part( 'template-parts/breadcrumbs' );
+				}
 				$count = 0;
 				/* Start the Loop */
 				while ( have_posts() ) :

--- a/themes/osi/page.php
+++ b/themes/osi/page.php
@@ -19,9 +19,12 @@ get_header(); ?>
 	<main class="content--body <?php echo esc_attr( osi_main_class() ); ?>" role="main">
 
 		<section class="content--page" id="content-page">
-			<?php get_template_part( 'template-parts/breadcrumbs' ); ?>
-
 			<?php
+			if ( 'event' === get_post_type() ) {
+				get_template_part( 'template-parts/breadcrumbs-sc_event' );
+			} else {
+				get_template_part( 'template-parts/breadcrumbs' );
+			}
 			while ( have_posts() ) :
 				the_post();
 

--- a/themes/osi/single.php
+++ b/themes/osi/single.php
@@ -13,9 +13,13 @@ get_header(); ?>
 
 	<main class="content--body <?php echo esc_attr( osi_main_class() ); ?>" role="main">
 		<section class="content--page" id="content-page">
-		<?php get_template_part( 'template-parts/breadcrumbs' ); ?>
-
 			<?php
+			if ( 'event' === get_post_type() ) {
+				get_template_part( 'template-parts/breadcrumbs-sc_event' );
+			} else {
+				get_template_part( 'template-parts/breadcrumbs' );
+			}
+			
 			while ( have_posts() ) :
 				the_post();
 

--- a/themes/osi/template-parts/breadcrumbs-sc_event.php
+++ b/themes/osi/template-parts/breadcrumbs-sc_event.php
@@ -3,15 +3,22 @@
 		<nav class="entry-breadcrumbs" itemscope="" itemtype="https://schema.org/BreadcrumbList">
 			<span itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
 				<meta itemprop="position" content="1">
-				<meta itemprop="position" content="0">
 				<a href="<?php echo esc_url( home_url( '/' ) ); ?>" class="home-link" itemprop="item" rel="home">
 					<span itemprop="name"><?php echo esc_html__( 'Home', 'osi' ); ?></span>
 				</a>
 			</span>
-			<span class="current-page" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
-				<meta itemprop="position" content="1">
-				<span itemprop="name"><?php echo esc_html__( 'Events', 'osi' ); ?></span>
+			<span itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
+				<meta itemprop="position" content="2">
+				<a href="<?php echo esc_url( home_url( '/events/' ) ); ?>" class="events-link" itemprop="item">
+					<span itemprop="name"><?php echo esc_html__( 'Events', 'osi' ); ?></span>
+				</a>
 			</span>
+			<?php if ( is_single() && get_post_type() == 'event' ) : ?>
+			<span class="current-page" itemprop="itemListElement" itemscope="" itemtype="https://schema.org/ListItem">
+				<meta itemprop="position" content="3">
+				<span itemprop="name"><?php echo esc_html( get_the_title() ); ?></span>
+			</span>
+			<?php endif; ?>
 		</nav>
 	</div><!-- .wrapper -->
 </div><!-- .breadcrumb-area -->

--- a/themes/osi/template-parts/header-featured-image.php
+++ b/themes/osi/template-parts/header-featured-image.php
@@ -14,7 +14,7 @@ if ( ! isset( $page_title ) ) {
 
 ?>
 
-<?php if ( has_post_thumbnail() && 'post' !== get_post_type( $post ) ) : ?>
+<?php if ( has_post_thumbnail() && 'post' !== get_post_type( $post ) ) { ?>
 	<header class="entry-header cover--header">
 		<div class="wp-block-cover alignfull">
 			<img class="wp-block-cover__image-background" alt="" src="<?php the_post_thumbnail_url(); ?>" data-object-fit="cover"/>
@@ -22,7 +22,15 @@ if ( ! isset( $page_title ) ) {
 			</div>
 		</div>
 	</header>
-<?php elseif ( is_page() ) : ?>
+<?php } else if ( ! has_post_thumbnail() && ! in_array( get_post_type( $post ), array( 'post', 'event' ), true ) ) { ?>
+	<header class="entry-header cover--header no-thumbnail">
+		<div class="wp-block-cover alignfull">
+			<div class="wp-block-cover__inner-container">
+				<?php osi_the_page_dates(); ?>
+			</div>
+		</div>
+	</header>
+<?php } elseif ( is_page() ) { ?>
 	<header class="entry-header cover--header no-thumbnail">
 		<div class="wp-block-cover alignfull has-neutral-dark-background-color has-background-dim-100 has-background-dim">
 			<div class="wp-block-cover__inner-container">
@@ -31,12 +39,4 @@ if ( ! isset( $page_title ) ) {
 			</div>
 		</div>
 	</header>
-<?php else : ?>
-	<header class="entry-header cover--header no-thumbnail">
-		<div class="wp-block-cover alignfull">
-			<div class="wp-block-cover__inner-container">
-				<?php osi_the_page_dates(); ?>
-			</div>
-		</div>
-	</header>
-<?php endif; ?>
+<?php } ?>

--- a/themes/osi/template-parts/header-featured-image.php
+++ b/themes/osi/template-parts/header-featured-image.php
@@ -1,5 +1,4 @@
 <?php
-
 if ( function_exists( 'Sugar_Calendar\AddOn\Ticketing\Settings\get_setting' ) ) {
 	$recepit_page_id = Sugar_Calendar\AddOn\Ticketing\Settings\get_setting( 'receipt_page' );
 
@@ -22,7 +21,7 @@ if ( ! isset( $page_title ) ) {
 			</div>
 		</div>
 	</header>
-<?php } else if ( ! has_post_thumbnail() && ! in_array( get_post_type( $post ), array( 'post', 'event' ), true ) ) { ?>
+<?php } elseif ( ! has_post_thumbnail() && ! in_array( get_post_type( $post ), array( 'post', 'event' ), true ) ) { ?>
 	<header class="entry-header cover--header no-thumbnail">
 		<div class="wp-block-cover alignfull">
 			<div class="wp-block-cover__inner-container">

--- a/themes/osi/template-parts/header-featured-image.php
+++ b/themes/osi/template-parts/header-featured-image.php
@@ -21,7 +21,7 @@ if ( ! isset( $page_title ) ) {
 			</div>
 		</div>
 	</header>
-<?php } elseif ( ! has_post_thumbnail() && ! in_array( get_post_type( $post ), array( 'post', 'event' ), true ) ) { ?>
+<?php } elseif ( ! has_post_thumbnail() && ! in_array( get_post_type( $post ), array( 'post', 'event', 'page' ), true ) ) { ?>
 	<header class="entry-header cover--header no-thumbnail">
 		<div class="wp-block-cover alignfull">
 			<div class="wp-block-cover__inner-container">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disable header for posts/events without featured image 
* Add breadcrumbs to the single Event page

#### Testing instructions

* Open an event page from the Frontend (like [this one](https://open-source-initiative-development.mystagingwebsite.com/events/open-source-ai-definition-town-hall-2024-06-14))
* Confirm that if the event has a featured image, it gets rendered in the header
* Confirm that if the event doesn't have any featured image, no blank space is rendered in the header

* Open a single event page from the Frontend
* Confirm that it has breadcrumbs, linking to the Home, the Events page and mentioning the current event.

Mentions https://github.com/a8cteam51/opensource-net/issues/50