### PR TITLE
Don't display the updated date for blog posts but published date

### DIFF
--- a/themes/osi/inc/template-tags.php
+++ b/themes/osi/inc/template-tags.php
@@ -14,8 +14,12 @@ if ( ! function_exists( 'osi_posted_on' ) ) :
 	function osi_posted_on( $format = '' ) {
 
 		$time_string = '<time class="byline--date entry-date published" datetime="%1$s">%2$s</time>';
-		if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
-			$time_string = '<time class="byline--date entry-date published updated" datetime="%3$s">%4$s</time>';
+		
+		// Don't display the updated date for blog posts.
+		if ( 'post' !== get_post_type() ) {
+			if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
+				$time_string .= '<time class="byline--date entry-date published updated" datetime="%3$s">%4$s</time>';
+			}
 		}
 
 		$time_string = sprintf(

--- a/themes/osi/inc/template-tags.php
+++ b/themes/osi/inc/template-tags.php
@@ -10,11 +10,13 @@
 if ( ! function_exists( 'osi_posted_on' ) ) :
 	/**
 	 * Prints HTML with meta information for the current post-date/time and author.
+	 *
+	 * @param string $format Date format.
 	 */
 	function osi_posted_on( $format = '' ) {
 
 		$time_string = '<time class="byline--date entry-date published" datetime="%1$s">%2$s</time>';
-		
+
 		// Don't display the updated date for blog posts.
 		if ( 'post' !== get_post_type() ) {
 			if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
@@ -36,7 +38,6 @@ if ( ! function_exists( 'osi_posted_on' ) ) :
 		);
 
 		echo '<span class="posted-on">' . $posted_on . '</span>'; // phpcs:ignore
-
 	}
 endif;
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Don't display the updated date for blog posts (and archive) but the published date

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The blog posts and blog archive should display the published date

Mentions #93 