### PR TITLE
Exclude meeting minutes post type for displaying updated time

### DIFF
--- a/themes/osi/inc/template-tags.php
+++ b/themes/osi/inc/template-tags.php
@@ -17,8 +17,8 @@ if ( ! function_exists( 'osi_posted_on' ) ) :
 
 		$time_string = '<time class="byline--date entry-date published" datetime="%1$s">%2$s</time>';
 
-		// Don't display the updated date for blog posts.
-		if ( 'post' !== get_post_type() ) {
+		// Don't display the updated date for blog posts and meeting-minutes.
+		if ( 'post' !== get_post_type() && 'meeting-minutes' !== get_post_type() ) {
 			if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
 				$time_string .= '<time class="byline--date entry-date published updated" datetime="%3$s">%4$s</time>';
 			}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Exclude meeting minutes post type for displaying updated time

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #93 