### PR TITLE
Always display comment block

### DIFF
--- a/themes/osi/template-parts/content.php
+++ b/themes/osi/template-parts/content.php
@@ -40,11 +40,8 @@
 		<?php the_content(); ?>
 	</div><!-- .entry-content -->
 	<?php 
-	//If comments are open or we have at least one comment, load up the comment template.
 	if ( 'board-member' === get_post_type() || 'post' === get_post_type() ) :
-		if ( comments_open() || get_comments_number() ) :
 			comments_template();
-		endif;
 	endif;
 	?>
 	<section id="pre-footer">


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Always display comment block
* Comments are on discourse, we need to display the board link even if no comments have been posted.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #