### PR TITLE
Feature : Non-OSI content links open in a new tab [PROD]

### DIFF
--- a/themes/osi/inc/template-functions.php
+++ b/themes/osi/inc/template-functions.php
@@ -228,7 +228,7 @@ function osi_the_page_dates() {
  *
  * @return string The processed content.
  */
-function osi_the_content( string $content ) {
+function osi_force_content_links_new_tab( string $content ) {
 	if ( ! em_is_event_rsvpable() ) {
 		// Instantiate the processor.
 		$processor = new \WP_HTML_Tag_Processor( $content );
@@ -258,4 +258,4 @@ function osi_the_content( string $content ) {
 	return $content;
 }
 
-add_filter( 'the_content', 'osi_the_content' );
+add_filter( 'the_content', 'osi_force_content_links_new_tab' );

--- a/themes/osi/inc/template-functions.php
+++ b/themes/osi/inc/template-functions.php
@@ -220,3 +220,42 @@ function osi_the_page_dates() {
 		}
 	}
 }
+
+/**
+ * Force external links to open in new tab.
+ *
+ * @param string $content The content to process.
+ *
+ * @return string The processed content.
+ */
+function osi_the_content( $content ) {
+	if ( ! em_is_event_rsvpable() ) {
+		// Instantiate the processor.
+		$processor = new \WP_HTML_Tag_Processor( $content );
+
+		// Get the domain of the site without scheme.
+		$site_domain = wp_parse_url( site_url(), PHP_URL_HOST );
+
+		// Loop through all the A tags and parse href to see if it's an external link.
+		while ( $processor->next_tag( 'A' ) ) {
+			$href        = $processor->get_attribute( 'href' );
+			$root_domain = wp_parse_url( $href, PHP_URL_HOST );
+
+			// If root domain is null, it's an internal link (no host), skip.
+			if ( null === $root_domain ) {
+				continue;
+			}
+
+			// If the root domain is not the same as the site domain, it's an external link.
+			if ( $root_domain !== $site_domain ) {
+				$processor->set_attribute( 'target', '_blank' );
+			}
+		}
+
+		return $processor->get_updated_html();
+	}
+
+	return $content;
+}
+
+add_filter( 'the_content', 'osi_the_content' );

--- a/themes/osi/inc/template-functions.php
+++ b/themes/osi/inc/template-functions.php
@@ -228,7 +228,7 @@ function osi_the_page_dates() {
  *
  * @return string The processed content.
  */
-function osi_the_content( $content ) {
+function osi_the_content( string $content ) {
 	if ( ! em_is_event_rsvpable() ) {
 		// Instantiate the processor.
 		$processor = new \WP_HTML_Tag_Processor( $content );

--- a/themes/osi/inc/template-functions.php
+++ b/themes/osi/inc/template-functions.php
@@ -229,7 +229,8 @@ function osi_the_page_dates() {
  * @return string The processed content.
  */
 function osi_force_content_links_new_tab( string $content ) {
-	if ( ! em_is_event_rsvpable() ) {
+	// Ensure Events Manager plugin is active and functionality for RSVPable events exists.
+	if ( function_exists( 'em_is_event_rsvpable' ) && ! em_is_event_rsvpable() ) {
 		// Instantiate the processor.
 		$processor = new \WP_HTML_Tag_Processor( $content );
 
@@ -252,7 +253,7 @@ function osi_force_content_links_new_tab( string $content ) {
 			}
 		}
 
-		return $processor->get_updated_html();
+		$content = $processor->get_updated_html();
 	}
 
 	return $content;


### PR DESCRIPTION
### Issue
- `Non-OSI` (`Open Source Initiative`) events to open in a `new tab`.

### Features
- Add a hook to the `the_content` filter and determine if an `event` is `Non-OSI`
- `Non-OSI` event is determined by checking whether event allows `Bookings/Registrations`
- All the links in the content that don't point to `opensource.org` are modified with `target="_blank"` attribute.