### PR TITLE
Remove 'blog' from CPT taxonomies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -354,11 +354,12 @@ GitHub.sublime-settings
 
 ### VisualStudioCode ###
 .vscode/*
-!.vscode/settings.json
+.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json
 !.vscode/extensions.json
 !.vscode/*.code-snippets
+themes/osi/.vscode/settings.json
 
 # Local History for Visual Studio Code
 .history/

--- a/plugins/osi-features/inc/classes/taxonomies/class-taxonomy-license-category.php
+++ b/plugins/osi-features/inc/classes/taxonomies/class-taxonomy-license-category.php
@@ -71,7 +71,10 @@ class Taxonomy_License_Category extends Base {
 		
 		return wp_parse_args( 
 			[
-				'rewrite'      => array( 'slug' => 'license-category' ),
+				'rewrite'      => array(
+					'slug' => 'license-category',
+					'with_front' => false,
+				),
 			], 
 			parent::get_args()
 		);

--- a/plugins/osi-features/inc/classes/taxonomies/class-taxonomy-publication.php
+++ b/plugins/osi-features/inc/classes/taxonomies/class-taxonomy-publication.php
@@ -72,7 +72,11 @@ class Taxonomy_Publication extends Base {
 		return wp_parse_args( 
 			[
 				'hierarchical' => true,
-				'rewrite'      => array( 'slug' => 'publication' ),
+				'rewrite'      => array(
+					'slug' => 'publication',
+					'with_front' => false,
+				),
+
 			], 
 			parent::get_args()
 		);

--- a/plugins/osi-features/inc/classes/taxonomies/class-taxonomy-seat-type.php
+++ b/plugins/osi-features/inc/classes/taxonomies/class-taxonomy-seat-type.php
@@ -72,7 +72,10 @@ class Taxonomy_Seat_Type extends Base {
 		return wp_parse_args( 
 			[
 				'hierarchical' => false,
-				'rewrite'      => array( 'slug' => 'seat-type' ),
+				'rewrite'      => array(
+					'slug' => 'seat-type',
+					'with_front' => false,
+				),
 			], 
 			parent::get_args()
 		);

--- a/plugins/osi-features/inc/classes/taxonomies/class-taxonomy-status.php
+++ b/plugins/osi-features/inc/classes/taxonomies/class-taxonomy-status.php
@@ -72,7 +72,11 @@ class Taxonomy_Status extends Base {
 		return wp_parse_args( 
 			[
 				'hierarchical' => false,
-				'rewrite'      => array( 'slug' => 'status' ),
+				'rewrite'      => array(
+					'slug' => 'about/board-of-directors',
+					'with_front' => false,
+					'hierarchical' => false,
+				),
 			], 
 			parent::get_args()
 		);

--- a/plugins/osi-features/inc/classes/taxonomies/class-taxonomy-steward.php
+++ b/plugins/osi-features/inc/classes/taxonomies/class-taxonomy-steward.php
@@ -72,7 +72,10 @@ class Taxonomy_Steward extends Base {
 		return wp_parse_args( 
 			[
 				'hierarchical' => false,
-				'rewrite'      => array( 'slug' => 'steward' ),
+				'rewrite'      => array(
+					'slug' => 'steward',
+					'with_front' => false,
+				),
 			], 
 			parent::get_args()
 		);


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* The Custom Post Type taxonomies were using the custom permalink (`/blog/%postname%`) when being viewed. This PR forces the removal of the pre-pended `/blog/` to the permalinks.
* Changes the "Status" taxonomy slug from `/status/` to `/about/board-of-directors/`.
  * **_Use caution with_** page and status taxonomy naming since we already have a page/child-page structure being used. Child pages of `/about/board-of-directors/` may cause unpredictable results.

#### Testing instructions

* Make sure to first "Save permalinks".
* View any of the taxonomies associated with any Custom Post Type. The `\blog\` in the permalink should not be present.

Mentions #115 , [4702](https://github.com/a8cteam51/team51-dev-requests/issues/4702)