### PR TITLE
Add filter to reduce the Discourse comment body to 50 words

### DIFF
--- a/themes/osi/functions.php
+++ b/themes/osi/functions.php
@@ -407,3 +407,16 @@ function osi_adjust_offset_pagination( int $found_posts, WP_Query $query ) {
 	return $found_posts;
 }
 add_filter( 'found_posts', 'osi_adjust_offset_pagination', 1, 2 );
+
+/**
+ * Trim the Discourse comment body to 50 words.
+ *
+ * @param string $comment_body The comment body.
+ *
+ * @return string The trimmed comment body.
+ */
+function osi_wpdc_comment_body( string $comment_body ) {
+	$trimmed_comment_body = wp_trim_words( $comment_body, 50, '(...)' );
+	return $trimmed_comment_body;
+}
+add_filter( 'wpdc_comment_body', 'osi_wpdc_comment_body', 10, 1 );


### PR DESCRIPTION
_**Part of work by Team51**_

#### Changes proposed in this Pull Request

* Trim the Discourse comment body to 50 words

SEE DEV VERSION INTO STAGING https://github.com/OpenSourceOrg/dotOrg/pull/138

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Discourse comment body should have a maximum length of 50 words

Mentions #