### PR TITLE
Only limit the number of posts to account for the sticky blog on page

### DIFF
--- a/themes/osi/functions.php
+++ b/themes/osi/functions.php
@@ -376,6 +376,11 @@ function osi_query_offset( WP_Query &$query ) {
 		return;
 	}
 
+	// If this is a page and its not set as the page for posts, return.
+	if ( (int) get_option( 'page_for_posts' ) !== (int) get_queried_object_id() ) {
+		return;
+	}
+
 	$offset = -1;
 	$ppp    = get_option( 'posts_per_page' );
 


### PR DESCRIPTION
…1 of blog list

# FOR PRODUCTION!!!!

#### Changes proposed in this Pull Request

* Ensures that only the blog list page will limit page 0 to 1 less post. Allowing board of directors to list all!

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Shows the 12th item (max of 20!)
![image](https://github.com/user-attachments/assets/aa1cc46f-a69d-48e4-85b2-b45f71a0a7f8)
* Shows 11 on page 1 of the latest blogs
![image](https://github.com/user-attachments/assets/c263e4f5-51ec-4c76-8416-f832dc555a2a)
![image](https://github.com/user-attachments/assets/5a48c071-130d-4173-9225-0e3a0de5b878)


Mentions #144 