### PR TITLE
CF7 to ACF Supporters

### DIFF
--- a/themes/osi/functions.php
+++ b/themes/osi/functions.php
@@ -425,3 +425,28 @@ function osi_wpdc_comment_body( string $comment_body ) {
 	return $trimmed_comment_body;
 }
 add_filter( 'wpdc_comment_body', 'osi_wpdc_comment_body', 10, 1 );
+
+/**
+ * 
+ * Create a new Supporter in ACF, based on a Contact Forms 7 submission.
+ * 
+ */
+add_action('wpcf7_before_send_mail', 'save_form_data_to_cpt');
+function save_form_data_to_cpt($contact_form) {
+    $submission = WPCF7_Submission::get_instance();
+    if ($submission) {
+        $data = $submission->get_posted_data();
+        
+        $post_id = wp_insert_post(array(
+            'post_title' => $data['your-name'],
+            'post_type' => 'supporter',
+            'post_status' => 'pending'
+        ));
+        update_field('name', $data['your-name'], $post_id);
+		update_field('organization', $data['your-org'], $post_id);
+		update_field('endorsement_type', $data['your-endorsement'], $post_id);
+		update_field('quote', $data['your-message'], $post_id);
+    } else {
+		error_log('WPCF7_Submission instance is null.');
+	}
+}


### PR DESCRIPTION
#### Changes proposed in this Pull Request

This PR adds a function to create a new supporter based on a CF7 submission, gets all the fields from the form and adds a new post in Pending Review mode.

#### Testing instructions
Go to https://open-source-initiative-development.mystagingwebsite.com/ai/endorsements, fill in the form, a new Supporter should be created