### PR TITLE
Add template support for the rest of the cpt (dev)

### DIFF
--- a/themes/osi/templates/template-no-header-title.php
+++ b/themes/osi/templates/template-no-header-title.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Template Name: No Header with Title
+ * Template Post Type: post, page, podcast, board-member, license, meeting-minutes, press-mentions, event, supporter
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Add template support for the rest of the cpt

#### Testing instructions
* Edit a podcast episode from the backend
* Click the template option in the sidebar and confirm that the `No Header with Title` template is available
* Assign this template to the episode and confirm it is rendered as expected.

Mentions #174