### PR TITLE
Custom permalink slug for podcasts (dev)

### DIFF
--- a/themes/osi/functions.php
+++ b/themes/osi/functions.php
@@ -578,3 +578,18 @@ add_action( 'after_setup_theme', 'osi_register_ai_menu' );
 
 
 add_filter( 'jetpack_disable_tracking', '__return_true' );
+
+/**
+ * Modify the post type arguments for the podcast post type.
+ *
+ * @param array $args The post type arguments.
+ *
+ * @return array The modified post type arguments.
+ */
+function osi_ssp_register_post_type_args( $args ) {
+	$args['rewrite']['slug']       = 'ai';
+	$args['rewrite']['with_front'] = false;
+	return $args;
+}
+add_filter( 'ssp_register_post_type_args', 'osi_ssp_register_post_type_args', 10, 1 );
+


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added a custom permalink slug for podcasts 

#### Testing instructions

* Go to Settings > Permalinks and confirm that the current structure is set to `/blog/%postname%`
* Open a podcast post from the frontend (following the link from the backend)
* Confirm that its URL is using a different permalink slug (`ai/podcast-post-name`)
* If you're getting a 404, flush the permalinks in Settings > General

Mentions #174