### PR TITLE
Added a custom permalink slug for podcasts

### DIFF
--- a/themes/osi/functions.php
+++ b/themes/osi/functions.php
@@ -507,3 +507,17 @@ function osi_handle_supporter_form_flamingo_spam_status_change( string $new_stat
 	}
 }
 add_action( 'transition_post_status', 'osi_handle_supporter_form_flamingo_spam_status_change', 10, 3 );
+
+/**
+ * Modify the post type arguments for the podcast post type.
+ *
+ * @param array $args The post type arguments.
+ *
+ * @return array The modified post type arguments.
+ */
+function osi_ssp_register_post_type_args( $args ) {
+	$args['rewrite']['slug']       = 'ai/podcast';
+	$args['rewrite']['with_front'] = false;
+	return $args;
+}
+add_filter( 'ssp_register_post_type_args', 'osi_ssp_register_post_type_args', 10, 1 );

--- a/themes/osi/templates/template-no-header-title.php
+++ b/themes/osi/templates/template-no-header-title.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * Template Name: No Header with Title
+ * Template Post Type: post, page, podcast, board-member, license, meeting-minutes, press-mentions, event, supporter
  *
  * @link https://codex.wordpress.org/Template_Hierarchy
  *


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added a custom permalink slug for podcasts 

#### Testing instructions

* Go to Settings > Permalinks and confirm that the current structure is set to `/blog/%postname%`
* Open a podcast post from the frontend (following the link from the backend)
* Confirm that its URL is using a different permalink slug (`ai/podcast-post-name`)
* If you're getting a 404, flush the permalinks in Settings > General

Mentions #174