### PR TITLE
Adjust status taxonomy visibility - main

### DIFF
--- a/plugins/osi-features/inc/classes/taxonomies/class-taxonomy-status.php
+++ b/plugins/osi-features/inc/classes/taxonomies/class-taxonomy-status.php
@@ -73,7 +73,7 @@ class Taxonomy_Status extends Base {
 				'hierarchical'       => false,
 				'rewrite'            => false,
 				'public'             => false,
-				'publicly_queryable' => false,
+				'publicly_queryable' => true,
 				'show_ui'            => true,
 				'show_in_menu'       => true,
 				'show_in_nav_menus'  => false,


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Change `'publicly_queryable'` to true so it appears in the query loop block.

Mentions #115 