### PR TITLE
Tweak Move ACF fields to OSI plugin - Develop

### DIFF
--- a/plugins/osi-features/inc/classes/taxonomies/class-taxonomy-publication.php
+++ b/plugins/osi-features/inc/classes/taxonomies/class-taxonomy-publication.php
@@ -28,7 +28,7 @@ class Taxonomy_Publication extends Base {
 	 */
 	public function get_labels() {
 
-		return [
+		return array(
 			'name'                       => _x( 'Publication', 'taxonomy general name', 'osi-features' ),
 			'singular_name'              => _x( 'Publication', 'taxonomy singular name', 'osi-features' ),
 			'search_items'               => __( 'Search Publication', 'osi-features' ),
@@ -45,8 +45,7 @@ class Taxonomy_Publication extends Base {
 			'choose_from_most_used'      => __( 'Choose from the most used Publications', 'osi-features' ),
 			'not_found'                  => __( 'No Publication found.', 'osi-features' ),
 			'menu_name'                  => __( 'Publications', 'osi-features' ),
-		];
-
+		);
 	}
 
 	/**
@@ -56,10 +55,9 @@ class Taxonomy_Publication extends Base {
 	 */
 	public function get_post_types() {
 
-		return [
+		return array(
 			Post_Type_Press_Mentions::get_instance()->get_slug(),
-		];
-
+		);
 	}
 
 	/**
@@ -68,18 +66,17 @@ class Taxonomy_Publication extends Base {
 	 * @return array
 	 */
 	public function get_args() {
-		
-		return wp_parse_args( 
-			[
+
+		return wp_parse_args(
+			array(
 				'hierarchical' => true,
+				'show_in_rest' => true,
 				'rewrite'      => array(
-					'slug' => 'publication',
+					'slug'       => 'publication',
 					'with_front' => false,
 				),
-
-			], 
+			),
 			parent::get_args()
 		);
 	}
-
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Added a new custom field to facilitate populating the Publication custom taxonomy.
* Make.com seems unable to include custom taxonomy values when creating a new post.
* This is a work-around which instead accepts the "Publication" (called "Outlet" in the google sheet) as a custom field and in the REST API route callback sets the value as taxonomy-publication value. The "value" from the spreadsheet is the publication name. It creates a new entry if it can't find an existing match.

Mentions #116 