### PR TITLE
Do not cast the term to regex if no wildcards to avoid the issues a t…

### DIFF
--- a/mu-plugins/osi-api/osi-api.php
+++ b/mu-plugins/osi-api/osi-api.php
@@ -136,13 +136,10 @@ class OSI_API {
 
 			$args['post_title_like'] = sanitize_text_field( $searched_slug ); // Use the post name (slug) to filter by ID
 		} elseif ( ! empty( $spdx ) ) {
-			// Cast the term to a regex pattern
-			$regex = $this->cast_wildcard_to_regex( $spdx );
-
 			// If we have no wildcards, look for a direct match
 			$args['meta_query'][] = array(
 				'key'     => 'spdx_identifier_display_text',
-				'value'   => $regex,
+				'value'   => str_contains( $spdx, '*' ) ? $this->cast_wildcard_to_regex( $spdx ) : sanitize_text_field( $spdx ),
 				'compare' => str_contains( $spdx, '*' ) ? 'REGEXP' : '==',
 			);
 		} elseif ( ! empty( $keyword ) ) {


### PR DESCRIPTION
…erm with no * is treated as a plan string match

#### Changes proposed in this Pull Request

* Fix issue where spdx=mit was treated as ^mit$ and not done using regex.

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

Mentions #199 