### PR TITLE
Adds the approved meta value for the licences, registered as part of …

### DIFF
--- a/plugins/osi-features/acf-fields/group_62d0160caa7af.json
+++ b/plugins/osi-features/acf-fields/group_62d0160caa7af.json
@@ -1,8 +1,7 @@
 {
     "key": "group_62d0160caa7af",
     "title": "License Data",
-    "fields": [
-        {
+    "fields": [{
             "key": "field_62fcd8910c9f7",
             "label": "Version",
             "name": "version",
@@ -42,41 +41,41 @@
             "first_day": 1
         },
         {
-          "key": "field_6783hdda5y544gf",
-          "label": "Submission URL",
-          "name": "submission_url",
-          "aria-label": "",
-          "type": "url",
-          "instructions": "",
-          "required": 0,
-          "conditional_logic": 0,
-          "wrapper": {
-            "width": "",
-            "class": "",
-            "id": ""
-          },
-          "default_value": "",
-          "placeholder": ""
+            "key": "field_6783hdda5y544gf",
+            "label": "Submission URL",
+            "name": "submission_url",
+            "aria-label": "",
+            "type": "url",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": ""
         },
         {
-          "key": "field_62fcda3b00451",
-          "label": "Submitter",
-          "name": "submitter",
-          "aria-label": "",
-          "type": "text",
-          "instructions": "",
-          "required": 0,
-          "conditional_logic": 0,
-          "wrapper": {
-            "width": "",
-            "class": "",
-            "id": ""
-          },
-          "default_value": "",
-          "placeholder": "",
-          "prepend": "",
-          "append": "",
-          "maxlength": ""
+            "key": "field_62fcda3b00451",
+            "label": "Submitter",
+            "name": "submitter",
+            "aria-label": "",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": "",
+            "maxlength": ""
         },
         {
             "key": "field_62fcd90c2f885",
@@ -112,28 +111,26 @@
                 "id": ""
             },
             "layout": "block",
-            "sub_fields": [
-                {
-                    "key": "field_62fcfcecb4ab2",
-                    "label": "Display Text",
-                    "name": "display_text",
-                    "aria-label": "",
-                    "type": "text",
-                    "instructions": "",
-                    "required": 0,
-                    "conditional_logic": 0,
-                    "wrapper": {
-                        "width": "",
-                        "class": "",
-                        "id": ""
-                    },
-                    "default_value": "",
-                    "placeholder": "",
-                    "prepend": "",
-                    "append": "",
-                    "maxlength": ""
-                }
-            ]
+            "sub_fields": [{
+                "key": "field_62fcfcecb4ab2",
+                "label": "Display Text",
+                "name": "display_text",
+                "aria-label": "",
+                "type": "text",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
+            }]
         },
         {
             "key": "field_62fcda1400450",
@@ -150,25 +147,23 @@
                 "id": ""
             },
             "layout": "block",
-            "sub_fields": [
-                {
-                    "key": "field_62fcda4d00452",
-                    "label": "URL",
-                    "name": "url",
-                    "aria-label": "",
-                    "type": "url",
-                    "instructions": "",
-                    "required": 0,
-                    "conditional_logic": 0,
-                    "wrapper": {
-                        "width": "",
-                        "class": "",
-                        "id": ""
-                    },
-                    "default_value": "",
-                    "placeholder": ""
-                }
-            ]
+            "sub_fields": [{
+                "key": "field_62fcda4d00452",
+                "label": "URL",
+                "name": "url",
+                "aria-label": "",
+                "type": "url",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": ""
+            }]
         },
         {
             "key": "field_62fcda6600453",
@@ -186,35 +181,53 @@
             },
             "relevanssi_exclude": 1,
             "layout": "block",
-            "sub_fields": [
-                {
-                    "key": "field_62fcda6600455",
-                    "label": "URL",
-                    "name": "url",
-                    "aria-label": "",
-                    "type": "url",
-                    "instructions": "",
-                    "required": 0,
-                    "conditional_logic": 0,
-                    "wrapper": {
-                        "width": "",
-                        "class": "",
-                        "id": ""
-                    },
-                    "default_value": "",
-                    "placeholder": ""
-                }
-            ]
+            "sub_fields": [{
+                "key": "field_62fcda6600455",
+                "label": "URL",
+                "name": "url",
+                "aria-label": "",
+                "type": "url",
+                "instructions": "",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": ""
+            }]
+        },
+        {
+            "key": "field_6855605992d38",
+            "label": "Approved",
+            "name": "approved",
+            "aria-label": "",
+            "type": "true_false",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "relevanssi_exclude": 0,
+            "message": "Denotes if a license has been approved",
+            "default_value": 0,
+            "allow_in_bindings": 0,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
         }
     ],
     "location": [
-        [
-            {
-                "param": "post_type",
-                "operator": "==",
-                "value": "license"
-            }
-        ]
+        [{
+            "param": "post_type",
+            "operator": "==",
+            "value": "license"
+        }]
     ],
     "menu_order": 0,
     "position": "side",
@@ -224,6 +237,6 @@
     "hide_on_screen": "",
     "active": true,
     "description": "",
-    "show_in_rest": 0,
-    "modified": 1686668177
+    "show_in_rest": 1,
+    "modified": 1750425728
 }


### PR DESCRIPTION
…the meta. Also adds the spdx query filter that comes with the use of wildcards to allow querying

#### Changes proposed in this Pull Request
 
* uses ACF to add a an approved meta value for licenses, this is then pulled into the JSON model of a license
* Adds the spdx filter, extended with the use of wildcards

#### Testing instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See the dev PR for more details https://github.com/OpenSourceOrg/dotOrg/pull/209

Mentions #199 