### PR TITLE
Fix for broken templates

### DIFF
--- a/themes/osi/functions.php
+++ b/themes/osi/functions.php
@@ -634,9 +634,18 @@ add_filter( 'em_booking_validate', 'osi_block_booking_if_phone_filled', 10, 2 );
 
 /**
  * Queuing swiper for the new home page rotating quotes
+ *
+ * @return void
 **/
-function osi_enqueue_swiper_assets() {
-    wp_enqueue_style('swiper-css', 'https://unpkg.com/swiper@11/swiper-bundle.min.css');
-    wp_enqueue_script('swiper-js', 'https://unpkg.com/swiper@11/swiper-bundle.min.js', [], null, true);
+function osi_enqueue_swiper_assets(): void {
+	wp_enqueue_style( 'swiper-css', 'https://unpkg.com/swiper@11/swiper-bundle.min.css', array(), filemtime( untrailingslashit( get_template_directory() ) . '/style.css' ) );
+	wp_enqueue_script( 'swiper-js', 'https://unpkg.com/swiper@11/swiper-bundle.min.js', array(), filemtime( untrailingslashit( get_template_directory() ) . '/style.css' ), true );
 }
-add_action('wp_enqueue_scripts', 'osi_enqueue_swiper_assets');
+add_action( 'wp_enqueue_scripts', 'osi_enqueue_swiper_assets' );
+
+/**
+ * Disable loading separate block styles for the osi theme.
+ *
+ * @return bool
+ */
+add_filter( 'should_load_separate_core_block_assets', '__return_false' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* 6.9 introduced performance improvement where the block styles are loaded only if used on the page which broke styling for some templates. This filter disables that behavior so the styles should load as expected.

#### Testing instructions

Visit this page https://open-source-initiative-development.mystagingwebsite.com/license/bsd-1-clause and styling shouldn't look broken.

Mentions #