### PR TITLE
Fix for broken templates after 6.9 update

### DIFF
--- a/themes/osi/functions.php
+++ b/themes/osi/functions.php
@@ -584,3 +584,10 @@ function osi_enqueue_swiper_assets(): void {
 	wp_enqueue_script( 'swiper-js', 'https://unpkg.com/swiper@11/swiper-bundle.min.js', array(), filemtime( untrailingslashit( get_template_directory() ) . '/style.css' ), true );
 }
 add_action( 'wp_enqueue_scripts', 'osi_enqueue_swiper_assets' );
+
+/**
+ * Disable loading separate block styles for the osi theme.
+ *
+ * @return bool
+ */
+add_filter( 'should_load_separate_core_block_assets', '__return_false' );


### PR DESCRIPTION
#### Changes proposed in this Pull Request

* Disables loading individual block styles which was a performance improvement in 6.9 but since osi theme uses styles like wp-block-columns in theme templates if we keep the loading of individual block styles enabled, it will break the template.

#### Testing instructions

Visit https://opensource.org/license/bsd-1-clause and the page shouldn't look broken.

Mentions #