### PR TITLE
Fix attachment-page & direct-access fatal errors in osi theme (develop)

### DIFF
--- a/themes/osi/inc/template-tags.php
+++ b/themes/osi/inc/template-tags.php
@@ -33,10 +33,7 @@ if ( ! function_exists( 'osi_posted_on' ) ) :
 			esc_html( get_the_modified_date( $format ) )
 		);
 
-		$posted_on = sprintf(
-			/* translators: %s: post date. */
-			'<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
-		);
+		$posted_on = '<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>';
 
 		echo '<span class="posted-on">' . $posted_on . '</span>'; // phpcs:ignore
 	}

--- a/themes/osi/index.php
+++ b/themes/osi/index.php
@@ -12,6 +12,8 @@
  * @package osi
  */
 
+defined( 'ABSPATH' ) || exit;
+
 get_header(); ?>
 
 <section class="content <?php echo ( osi_display_sidebar() ? 'has_sidebar' : 'has_no_sidebar' ); ?>" id="content">


### PR DESCRIPTION
## Problem

Two PHP fatal errors reported in the `osi` theme:

1. **`ArgumentCountError: 43 arguments are required, 1 given`** in `inc/template-tags.php:36` (`osi_posted_on()`), triggered when rendering **attachment pages** (`single.php → get_template_part('template-parts/content','attachment') → osi_posted_on()`). This is visitor-facing and white-screens the page.
2. **`Call to undefined function get_header()`** in `index.php:15`, triggered by **direct HTTP requests** to the theme file (bots/scanners hitting `/wp-content/themes/osi/index.php`), where WordPress is never bootstrapped. Log noise, not visitor-facing.

## Root cause

**#1** — `osi_posted_on()` called `sprintf()` with only a format string and **no arguments**:

```php
$posted_on = sprintf(
    '<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
);
```

The "format string" contains the permalink. On attachment pages the URL can contain a literal `%` (e.g. `%43`), which `sprintf` interprets as positional placeholder `%43$…` → `ArgumentCountError`. There were never any placeholders to substitute.

## Fix

- Replace the pointless `sprintf()` with plain string concatenation.
- Add `defined( 'ABSPATH' ) || exit;` guard to `index.php` so direct file requests exit cleanly instead of fataling.

Both files pass `php -l`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Develop-branch counterpart of the `main` PR — use this one for testing._